### PR TITLE
Fix for Xcode 12.5

### DIFF
--- a/DeallocTests.podspec
+++ b/DeallocTests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
  s.name = 'DeallocTests'
- s.version = '1.0.1'
+ s.version = '1.0.2'
  s.license = { :type => "MIT", :file => "LICENSE" }
  s.summary = 'Easy-to-use framework for custom deallocation tests.'
  s.homepage = 'http://strv.com'
@@ -15,9 +15,10 @@ Pod::Spec.new do |s|
    'APPLICATION_EXTENSION_API_ONLY' => 'YES',
    'DEFINES_MODULE' => 'YES',
    'ENABLE_BITCODE' => 'NO',
-   'OTHER_LDFLAGS' => '$(inherited) -weak-lswiftXCTest -Xlinker -no_application_extension',
+   'OTHER_LDFLAGS' => '$(inherited) -weak-lXCTestSwiftSupport -Xlinker -no_application_extension',
    'OTHER_SWIFT_FLAGS' => '$(inherited) -suppress-warnings',
    'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"',
+   "ENABLE_TESTING_SEARCH_PATHS" => "YES", # Required for Xcode 12.5
  }
 
  s.default_subspec = "SwinjectBased"

--- a/DeallocTests.xcodeproj/project.pbxproj
+++ b/DeallocTests.xcodeproj/project.pbxproj
@@ -477,7 +477,7 @@
 					"$(inherited)",
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
+					"-weak-lXCTestSwiftSupport",
 					"-Xlinker",
 					"-no_application_extension",
 				);
@@ -517,7 +517,7 @@
 					"$(inherited)",
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
+					"-weak-lXCTestSwiftSupport",
 					"-Xlinker",
 					"-no_application_extension",
 				);
@@ -678,7 +678,7 @@
 					"$(inherited)",
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
+					"-weak-lXCTestSwiftSupport",
 					"-Xlinker",
 					"-no_application_extension",
 				);
@@ -718,7 +718,7 @@
 					"$(inherited)",
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
+					"-weak-lXCTestSwiftSupport",
 					"-Xlinker",
 					"-no_application_extension",
 				);

--- a/README.md
+++ b/README.md
@@ -85,13 +85,15 @@ import PackageDescription
 let package = Package(
     name: "HelloDeallocTests",
     dependencies: [
-        .package(url: "https://github.com/DanielCech/DeallocTests.git", .upToNextMajor(from: "1.0.0"))
+        .package(url: "https://github.com/strvcom/DeallocTests.git", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [
         .target(name: "HelloDeallocTests", dependencies: ["DeallocTests"])
     ]
 )
 ```
+__WARNING__: When you install DeallocTests with SPM and you use Xcode 12.5+ you must set `ENABLE_TESTING_SEARCH_PATHS` to `YES` in your testing target build settings.
+
 </details>
 
 ### Manually

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ let package = Package(
     ]
 )
 ```
-__WARNING__: When you install DeallocTests with SPM and you use Xcode 12.5+ you must set `ENABLE_TESTING_SEARCH_PATHS` to `YES` in your testing target build settings.
+__WARNING__: When you install DeallocTests with SPM and you use Xcode 12.5+ you must set `ENABLE_TESTING_SEARCH_PATHS` to `YES` in your app target build settings.
 
 </details>
 


### PR DESCRIPTION
### Goals :soccer:
- The library stopped working in Xcode 12.5 because the legacy `libswiftXCTest.dylib` library is not included anymore

### Implementation Details :construction:
- The `libswiftXCTest.dylib` was replaced with `libXCTestSwiftSupport.dylib`
- `ENABLE_TESTING_SEARCH_PATHS=YES` requirement was added to Readme
- The changes were reflected in the Podspec

### Testing Details :mag:
- Build and run the project
- Install pods locally and test it
