### PR TITLE
Make DeallocTester a @MainActor

### DIFF
--- a/Sources/DeallocTests/DeallocTester.swift
+++ b/Sources/DeallocTests/DeallocTester.swift
@@ -41,6 +41,7 @@ public struct DeallocTest {
     }
 }
 
+@MainActor
 open class DeallocTester: XCTestCase {
     // MARK: - Properties
 


### PR DESCRIPTION
### Goals :soccer:
Allows testing of classes that have `init` marked as a `@MainActor`.

During unit test creation of `iWeather` it was discovered that in order to inject `State` into stores the `init` needs to be marked as `@MainActor` which resulted into failing dealloc tests since the dependency registration and resolving now also has to be `@MainActor`.

### Implementation Details :construction:
Marks `DeallocTester` with `@MainActor`

### Testing Details :mag:
- no tests were identified to cover this change
